### PR TITLE
Fixes and improvements

### DIFF
--- a/jbuild
+++ b/jbuild
@@ -173,19 +173,19 @@ done
 # Parse command-line options and arguments, send to functions as needed
 while [[ $# -gt 0 ]]; do
   case "$1" in
-        -b | --build | build)
+        (-b | --build | build)
             build_iso
             exit 0
         ;;
-        -r | --run | run)
+        (-r | --run | run)
             run_iso "$2"
             exit 0
         ;;
-        -c | --clean | clean)
+        (-c | --clean | clean)
             clean
             exit 0
         ;;
-        -p | --profile | profile)
+        (-p | --profile | profile)
             # If no profile is specified, list available profiles
             if (( "${#2}" )); then
                 # If no path is specified, use the default path
@@ -205,20 +205,20 @@ while [[ $# -gt 0 ]]; do
                 exit 1
             fi
         ;;
-        --profiles | profiles)
+        (--profiles | profiles)
             # If no profile is specified, list available profiles
             list_profiles
             exit 1
         ;;
-        -h | --help | help)
+        (-h | --help | help)
             usage
             exit 0
         ;;
-        -v | --version | version)
+        (-v | --version | version)
             version
             exit 0
         ;;
-        *)
+        (*)
             echo "Invalid option: ${1@Q}" >&2
             usage
             exit 1

--- a/jbuild
+++ b/jbuild
@@ -10,7 +10,6 @@ readonly SOURCE="archlive"
 readonly LIVEROOT="airootfs"
 readonly CONFIG="jovarkos-config"
 
-
 function error() {
     printf "$*\n" >&2
 }

--- a/jbuild
+++ b/jbuild
@@ -33,11 +33,6 @@ function clean () {
     sudo rm -rf ${WORKING}
 }
 
-function no_mkarchiso () {
-    error "mkarchiso is not installed. Please install it and try again."
-    exit 1
-}
-
 function build_iso() {
     no_archiso_dir
     echo "Clearing ${WORKING} directory before beginning..."
@@ -161,26 +156,20 @@ USAGE
 version
 }
 
-if ! command -v mkarchiso &> /dev/null; then
-    error "mkarchiso is not installed. Please install it and try again."
-cat << ERROR
-To install mkarchiso:
-    sudo pacman -S mkarchiso
-ERROR
-    exit 1
-fi
+m=0
 
+for dep in make mkarchiso; do
+    type -P "${dep}" &> /dev/null || {
 
-if ! command -v make &> /dev/null; then
-    error "make is not installed. Please install it and try again."
-cat << ERROR
-To install mkarchiso:
-    sudo pacman -S make
-ERROR
-    exit 1
-fi
+        error "${dep} is not installed. Please install it and try again."
 
+        # Count missing dependencies
+        (( m++ ))
+    }
+done
 
+# Fail when one or more are missing
+(( m )) && exit 1
 
 # Parse command-line options and arguments, send to functions as needed
 while [[ $# -gt 0 ]]; do

--- a/jbuild
+++ b/jbuild
@@ -176,15 +176,15 @@ while [[ $# -gt 0 ]]; do
         -b | --build | build)
             build_iso
             exit 0
-            ;;
+        ;;
         -r | --run | run)
             run_iso "$2"
             exit 0
-            ;;
+        ;;
         -c | --clean | clean)
             clean
             exit 0
-            ;;
+        ;;
         -p | --profile | profile)
             # If no profile is specified, list available profiles
             if (( "${#2}" )); then
@@ -204,16 +204,16 @@ while [[ $# -gt 0 ]]; do
                 list_profiles
                 exit 1
             fi
-            ;;
+        ;;
         --profiles | profiles)
             # If no profile is specified, list available profiles
             list_profiles
             exit 1
-            ;;
+        ;;
         -h | --help | help)
             usage
             exit 0
-            ;;
+        ;;
         -v | --version | version)
             version
             exit 0

--- a/jbuild
+++ b/jbuild
@@ -58,7 +58,7 @@ function confirm_run() {
         echo "Running ISO..."
         qemu-system-x86_64 \
         -boot order=d,menu=on,reboot-timeout=5000 \
-        -m "size=3072,slots=0,maxmem=$((3072*1024*1024))" \
+        -m size=3072,slots=0,maxmem=$((3072*1024*1024)) \
         -smp 2 \
         -k en-us \
         -name archiso,process=archiso_0 \
@@ -83,7 +83,7 @@ function confirm_run() {
 function run_iso() {
     qemu-system-x86_64 \
         -boot order=d,menu=on,reboot-timeout=5000 \
-        -m "size=3072,slots=0,maxmem=$((3072*1024*1024))" \
+        -m size=3072,slots=0,maxmem=$((3072*1024*1024)) \
         -smp 2 \
         -k en-us \
         -name archiso,process=archiso_0 \

--- a/jbuild
+++ b/jbuild
@@ -191,13 +191,10 @@ while (( $# )); do
                 # If no path is specified, use the default path
                 if (( "${#3}" )); then
                     # If a path is specified, use that path
-                    PROFILE="$2"
-                    SOURCE="$3"
-                    profile ${PROFILE} ${SOURCE}
+                    profile "$2" "$3"
                     exit 0
                 else
-                    PROFILE="$2"
-                    profile ${PROFILE}
+                    profile "$2"
                     exit 0
                 fi
             else

--- a/jbuild
+++ b/jbuild
@@ -58,7 +58,7 @@ function confirm_run() {
         echo "Running ISO..."
         qemu-system-x86_64 \
         -boot order=d,menu=on,reboot-timeout=5000 \
-        -m size=3072,slots=0,maxmem=$((3072*1024*1024)) \
+        -m size=3072,slots=0,maxmem=$((3 << 20)) \
         -smp 2 \
         -k en-us \
         -name archiso,process=archiso_0 \
@@ -83,7 +83,7 @@ function confirm_run() {
 function run_iso() {
     qemu-system-x86_64 \
         -boot order=d,menu=on,reboot-timeout=5000 \
-        -m size=3072,slots=0,maxmem=$((3072*1024*1024)) \
+        -m size=3072,slots=0,maxmem=$((3 << 20)) \
         -smp 2 \
         -k en-us \
         -name archiso,process=archiso_0 \

--- a/jbuild
+++ b/jbuild
@@ -44,7 +44,7 @@ function build_iso() {
     sudo rm -rf ${WORKING}
     if [[ ! -d "${CONFIG}" ]]; then
         echo "JovarkOS configuration directory not found in $(pwd). Skipping..."
-    else 
+    else
         echo "${CONFIG} directory already exists. Continuing..."
         echo "Copying ${CONFIG}/archlive to $(pwd)..."
         sudo cp ${CONFIG}/archlive . -r
@@ -126,7 +126,7 @@ function profile() {
     if [[ -z "$1" ]]; then
         list_profiles
         exit 1
-    else 
+    else
         if [[ -z "$2" ]]; then
             cp -r "/usr/share/archiso/configs/$1" ${SOURCE}
             echo "Copied profile $1 to ${SOURCE}"
@@ -202,13 +202,13 @@ while [[ $# -gt 0 ]]; do
             if [[ -z "$2" ]]; then
                 list_profiles
                 exit 1
-            else 
+            else
                 # If no path is specified, use the default path
                 if [[ -z "$3" ]]; then
                     PROFILE="$2"
                     profile ${PROFILE}
                     exit 0
-                else 
+                else
                     # If a path is specified, use that path
                     PROFILE="$2"
                     SOURCE="$3"

--- a/jbuild
+++ b/jbuild
@@ -123,22 +123,22 @@ ls /usr/share/archiso/configs/
 
 function profile() {
     # If no profile is specified, list available profiles
-    if [[ -z "$1" ]]; then
-        list_profiles
-        exit 1
-    else
-        if [[ -z "$2" ]]; then
-            cp -r "/usr/share/archiso/configs/$1" ${SOURCE}
-            echo "Copied profile $1 to ${SOURCE}"
-            echo ""
-            echo "Please edit files in ${SOURCE} to customize your ISO. Then run 'jbuild -b' from $(pwd) to build your ISO"
-        else
+    if (( "${#1}" )); then
+        if (( "${#2}" )); then
             # If no path is specified, use the default path
             cp -r "/usr/share/archiso/configs/$1" $2
             echo "Copied profile $1 to $2"
             echo ""
             echo "Please edit files in $2 to customize your ISO. Then run 'jbuild -b' from $(pwd) to build your ISO"
+        else
+            cp -r "/usr/share/archiso/configs/$1" ${SOURCE}
+            echo "Copied profile $1 to ${SOURCE}"
+            echo ""
+            echo "Please edit files in ${SOURCE} to customize your ISO. Then run 'jbuild -b' from $(pwd) to build your ISO"
         fi
+    else
+        list_profiles
+        exit 1
     fi
 }
 
@@ -199,22 +199,22 @@ while [[ $# -gt 0 ]]; do
             ;;
         -p | --profile | profile)
             # If no profile is specified, list available profiles
-            if [[ -z "$2" ]]; then
-                list_profiles
-                exit 1
-            else
+            if (( "${#2}" )); then
                 # If no path is specified, use the default path
-                if [[ -z "$3" ]]; then
-                    PROFILE="$2"
-                    profile ${PROFILE}
-                    exit 0
-                else
+                if (( "${#3}" )); then
                     # If a path is specified, use that path
                     PROFILE="$2"
                     SOURCE="$3"
                     profile ${PROFILE} ${SOURCE}
                     exit 0
+                else
+                    PROFILE="$2"
+                    profile ${PROFILE}
+                    exit 0
                 fi
+            else
+                list_profiles
+                exit 1
             fi
             ;;
         --profiles | profiles)

--- a/jbuild
+++ b/jbuild
@@ -105,7 +105,7 @@ function run_iso() {
         -enable-kvm \
         -serial stdio \
         -no-reboot \
-        -cdrom "${OPTARG}"
+        -cdrom "$1"
 }
 
 function list_profiles() {
@@ -190,7 +190,7 @@ while [[ $# -gt 0 ]]; do
             exit 0
             ;;
         -r | --run | run)
-            run_iso
+            run_iso "$2"
             exit 0
             ;;
         -c | --clean | clean)

--- a/jbuild
+++ b/jbuild
@@ -218,16 +218,6 @@ while [[ $# -gt 0 ]]; do
             version
             exit 0
         ;;
-        -\? | --?)
-            echo "Invalid option: -$#" >&2
-            usage
-            exit 1
-        ;;
-        :)
-            echo "Option -$# requires an argument." >&2
-            usage
-            exit 1
-        ;;
         *)
             echo "Invalid option: -$#" >&2
             usage

--- a/jbuild
+++ b/jbuild
@@ -219,7 +219,7 @@ while [[ $# -gt 0 ]]; do
             exit 0
         ;;
         *)
-            echo "Invalid option: $1" >&2
+            echo "Invalid option: ${1@Q}" >&2
             usage
             exit 1
         ;;

--- a/jbuild
+++ b/jbuild
@@ -171,7 +171,7 @@ done
 (( m )) && exit 1
 
 # Parse command-line options and arguments, send to functions as needed
-while [[ $# -gt 0 ]]; do
+while (( $# )); do
   case "$1" in
         (-b | --build | build)
             build_iso
@@ -226,9 +226,9 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-# If no arguments are provided, print help and exit
-if [[ $# -eq 0 ]]; then
+(( $# )) || {
+
     error "ERROR: Please provide an argument.\n"
     usage
     exit 1
-fi
+}

--- a/jbuild
+++ b/jbuild
@@ -219,7 +219,7 @@ while [[ $# -gt 0 ]]; do
             exit 0
         ;;
         *)
-            echo "Invalid option: -$#" >&2
+            echo "Invalid option: $1" >&2
             usage
             exit 1
         ;;


### PR DESCRIPTION
## Improvements

* Single quoted invalid options in error messages (*e.g* `'--invalid-option'`)
* Removed unnecessary patterns from `case` compound command
* Shortened commands to check parameter lengths and values
* Used bitwise left shift to calculate option argument

## Fixes

* Print invalid option instead of command line argument count
* Passed ISO file path to `run_iso`  function
* Deleted trailing whitespace characters

I indented code using 4 spaces since there is no established style.